### PR TITLE
Improve Games Show Page

### DIFF
--- a/app/assets/stylesheets/components/_game-banner.scss
+++ b/app/assets/stylesheets/components/_game-banner.scss
@@ -1,0 +1,22 @@
+.game-banner {
+    background-size: cover;
+    background-position: center;
+    padding: 150px 0;
+    height:500px;
+  }
+  
+  .game-banner h1 {
+    margin: 0;
+    color: white;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+    font-size: 32px;
+    font-weight: bold;
+  }
+  
+  .game-banner p {
+    font-size: 20px;
+    color: white;
+    opacity: .7;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+  }
+  

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,4 +3,5 @@
 @import "avatar";
 @import "banner";
 @import "cardcategory";
+@import "game-banner";
 @import "navbar";

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,6 @@
 
 
-<div class="game-banner" style="background-image: linear-gradient(rgba(213,2,75,0.4),rgba(255,104,37,0.4)), url(https://cdn.akamai.steamstatic.com/steam/apps/10/page_bg_generated_v6b.jpg);">
+<div class="game-banner" style="background-image: linear-gradient(rgba(213,2,75,0.4),rgba(255,104,37,0.4)), url(<% @game.background_image_url %>);">
   <div class="container d-flex justify-content-between">
     <div class="container">
         <img src="<%= @game.image_url %>" alt="game-splash-art">
@@ -12,5 +12,7 @@
     </div>
   </div>
 </div>
+
+
 
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,12 @@
-<h1><%= @game.title %></h1>
-<h6><%= @game.description %></h6>
-<h5>Developed by: <%= @game.developer %></h5>
 
 
-<img src="<%=@game.image_url %>" alt="game_splash_art">
+<div class="game-banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://cdn.akamai.steamstatic.com/steam/apps/20/page_bg_generated_v6b.jpg);">
+  <div class="container">
+    <img src="<%= @game.image_url %>" alt="game-splash-art">
+    <h1><%= @game.title %></p>
+    <p><%= @game.description %></p>
+    <p>Developed by: <%= @game.developer %></h5>
+  </div>
+</div>
+
+

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,6 @@
 
 
-<div class="game-banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://cdn.akamai.steamstatic.com/steam/apps/20/page_bg_generated_v6b.jpg);">
+<div class="game-banner" style="background-image: linear-gradient(rgba(213,2,75,0.4),rgba(255,104,37,0.4)), url(https://cdn.akamai.steamstatic.com/steam/apps/10/page_bg_generated_v6b.jpg);">
   <div class="container d-flex justify-content-between">
     <div class="container">
         <img src="<%= @game.image_url %>" alt="game-splash-art">

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,11 +1,15 @@
 
 
 <div class="game-banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://cdn.akamai.steamstatic.com/steam/apps/20/page_bg_generated_v6b.jpg);">
-  <div class="container">
-    <img src="<%= @game.image_url %>" alt="game-splash-art">
-    <h1><%= @game.title %></p>
-    <p><%= @game.description %></p>
-    <p>Developed by: <%= @game.developer %></h5>
+  <div class="container d-flex justify-content-between">
+    <div class="container">
+        <img src="<%= @game.image_url %>" alt="game-splash-art">
+    </div>
+    <div class="container">
+        <h1><%= @game.title %></p>
+        <p><%= @game.description %></p>
+        <p>Developed by: <%= @game.developer %></p>
+    </div>
   </div>
 </div>
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,6 @@
 
 
-<div class="game-banner" style="background-image: linear-gradient(rgba(213,2,75,0.4),rgba(255,104,37,0.4)), url(<% @game.background_image_url %>);">
+<div class="game-banner" style="background-image: linear-gradient(rgba(213,2,75,0.4),rgba(255,104,37,0.4)), url(<%= @game.background_image_url %>);">
   <div class="container d-flex justify-content-between">
     <div class="container">
         <img src="<%= @game.image_url %>" alt="game-splash-art">

--- a/db/migrate/20210901163845_add_background_img_url_to_game_table.rb
+++ b/db/migrate/20210901163845_add_background_img_url_to_game_table.rb
@@ -1,0 +1,5 @@
+class AddBackgroundImgUrlToGameTable < ActiveRecord::Migration[6.1]
+  def change
+    add_column :games, :background_image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_01_113943) do
+ActiveRecord::Schema.define(version: 2021_09_01_163845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2021_09_01_113943) do
     t.string "image_url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "background_image_url"
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ def top_100_games
                 image_url: "https://cdn.cloudflare.steamstatic.com/steam/apps/#{appid}/header.jpg",
                 developer: element[1]["developer"],
                 description: game_description(appid),
-                genre: game_genres(appid)
+                genre: game_genres(appid),
                 background_image_url: "https://cdn.akamai.steamstatic.com/steam/apps/#{appid}/page_bg_generated_v6b.jpg")
     p "#{Game.count}/100 - Created Game: #{element[1]["name"]}"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,8 @@ def top_100_games
                 image_url: "https://cdn.cloudflare.steamstatic.com/steam/apps/#{appid}/header.jpg",
                 developer: element[1]["developer"],
                 description: game_description(appid),
-                genre: game_genres(appid))
+                genre: game_genres(appid)
+                background_image_url: "https://cdn.akamai.steamstatic.com/steam/apps/#{appid}/page_bg_generated_v6b.jpg")
     p "#{Game.count}/100 - Created Game: #{element[1]["name"]}"
   end
 end


### PR DESCRIPTION
### Games show page

Make some improvements to Games show page so it looks a little cleaner.
We can add a dynamic background provided by steam, but would need to add another background_image_url column to the games table. This is to follow on approval.

![chrome-capture](https://user-images.githubusercontent.com/16850455/131696259-38eef3a2-bbb3-4005-96eb-b6b28b350ec1.jpg)
