### PR TITLE
User Information

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,17 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    # For additional fields in app/views/devise/registrations/new.html.erb
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :dob, :gender, :region])
+
+    # For additional in app/views/devise/registrations/edit.html.erb
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username, :dob, :gender, :region, 
+                                                              :steam_handle, :origin_handle, 
+                                                              :psn_handle, :epic_handle, 
+                                                              :discord_handle, :live_handle, 
+                                                              :gog_handle, :twich_handle, 
+                                                              :battlenet_handle])
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,35 +1,59 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container">
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
+  <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= f.error_notification %>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
-    <% end %>
+    <div class="form-inputs">
+      <%= f.input :email, required: true, autofocus: true %>
 
-    <%= f.input :password,
-                hint: "leave it blank if you don't want to change it",
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :current_password,
-                hint: "we need your current password to confirm your changes",
-                required: true,
-                input_html: { autocomplete: "current-password" } %>
-  </div>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+      <% end %>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Update" %>
-  </div>
-<% end %>
+      <%= f.input :password,
+                  hint: "leave it blank if you don't want to change it",
+                  required: false,
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation,
+                  required: false,
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :current_password,
+                  hint: "we need your current password to confirm your changes",
+                  required: true,
+                  input_html: { autocomplete: "current-password" } %>
+      <%= f.input :region, :collection => ["Europe",
+                                       "North America",
+                                       "South America",
+                                       "Africa",
+                                       "Middle East",
+                                       "East Asia",
+                                       "Southeast Asia",
+                                       "Australia & Pacific",
+                                       "Antarctica"] %>
+      <%= f.input :dob, as: :date %>
+      <%= f.input :gender, :collection => ["Male", "Female", "Other", "Prefer not to say"] %>             
+      <%= f.input :steam_handle %>
+      <%= f.input :origin_handle %>
+      <%= f.input :psn_handle %>
+      <%= f.input :epic_handle %>
+      <%= f.input :discord_handle %>
+      <%= f.input :live_handle %>
+      <%= f.input :gog_handle %>
+      <%= f.input :twich_handle %>
+      <%= f.input :battlenet_handle %>
+    </div>
 
-<h3>Cancel my account</h3>
+    <div class="form-actions">
+      <%= f.button :submit, "Update" %>
+    </div>
+  <% end %>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+  <h3>Cancel my account</h3>
 
-<%= link_to "Back", :back %>
+  <p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+  <%= link_to "Back", :back %>
+
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mt-3">
 
   <h2>Edit <%= resource_name.to_s.humanize %></h2>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,7 +23,11 @@
                   hint: "we need your current password to confirm your changes",
                   required: true,
                   input_html: { autocomplete: "current-password" } %>
-      <%= f.input :username %>
+      <%= f.input :username, required: true, autofocus: true  %>
+      <%= f.input :dob, as: :date, start_year: Date.today.year - 90,
+                              end_year: Date.today.year - 18,
+                              order: [:day, :month, :year] %>
+      <%= f.input :gender, collection: ["Male", "Female", "Other", "Prefer not to say"], required: true, autofocus: true  %>        
       <%= f.input :region, collection: ["Europe",
                                        "North America",
                                        "South America",
@@ -32,11 +36,7 @@
                                        "East Asia",
                                        "Southeast Asia",
                                        "Australia & Pacific",
-                                       "Antarctica"] %>
-      <%= f.input :dob, as: :date, start_year: Date.today.year - 90,
-                              end_year: Date.today.year - 18,
-                              order: [:day, :month, :year] %>
-      <%= f.input :gender, collection: ["Male", "Female", "Other", "Prefer not to say"] %>             
+                                       "Antarctica"], required: true, autofocus: true  %>
       <%= f.input :steam_handle %>
       <%= f.input :origin_handle %>
       <%= f.input :psn_handle %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,7 +11,7 @@
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
       <% end %>
-
+      
       <%= f.input :password,
                   hint: "leave it blank if you don't want to change it",
                   required: false,
@@ -23,7 +23,8 @@
                   hint: "we need your current password to confirm your changes",
                   required: true,
                   input_html: { autocomplete: "current-password" } %>
-      <%= f.input :region, :collection => ["Europe",
+      <%= f.input :username %>
+      <%= f.input :region, collection: ["Europe",
                                        "North America",
                                        "South America",
                                        "Africa",
@@ -32,8 +33,10 @@
                                        "Southeast Asia",
                                        "Australia & Pacific",
                                        "Antarctica"] %>
-      <%= f.input :dob, as: :date %>
-      <%= f.input :gender, :collection => ["Male", "Female", "Other", "Prefer not to say"] %>             
+      <%= f.input :dob, as: :date, start_year: Date.today.year - 90,
+                              end_year: Date.today.year - 18,
+                              order: [:day, :month, :year] %>
+      <%= f.input :gender, collection: ["Male", "Female", "Other", "Prefer not to say"] %>             
       <%= f.input :steam_handle %>
       <%= f.input :origin_handle %>
       <%= f.input :psn_handle %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,25 +1,40 @@
-<h2>Sign up</h2>
+<div class="container"><h2>Sign up</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
-                required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
-  </div>
+    <div class="form-inputs">
+      <%= f.input :email,
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" }%>
+      <%= f.input :password,
+                  required: true,
+                  hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation,
+                  required: true,
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :username %>
+      <%= f.input :region, collection: ["Europe",
+                                       "North America",
+                                       "South America",
+                                       "Africa",
+                                       "Middle East",
+                                       "East Asia",
+                                       "Southeast Asia",
+                                       "Australia & Pacific",
+                                       "Antarctica"], required: true, autofocus: true  %>
+      <%= f.input :dob, as: :date, start_year: Date.today.year - 90,
+                              end_year: Date.today.year - 18,
+                              order: [:day, :month, :year] %>
+      <%= f.input :gender, collection: ["Male", "Female", "Other", "Prefer not to say"], required: true, autofocus: true  %>
+    </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
-<% end %>
+    <div class="form-actions">
+      <%= f.button :submit, "Sign up" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,5 @@
-<div class="container"><h2>Sign up</h2>
+<div class="container mt-3">
+<h2>Sign up</h2>
 
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= f.error_notification %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,20 +1,22 @@
-<h2>Log in</h2>
+<div class="container mt-3">
+  <h2>Log in</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-  </div>
+  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="form-inputs">
+      <%= f.input :email,
+                  required: false,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" } %>
+      <%= f.input :password,
+                  required: false,
+                  input_html: { autocomplete: "current-password" } %>
+      <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+    </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
+    <div class="form-actions">
+      <%= f.button :submit, "Log in" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "edit profile", edit_user_registration_path %>


### PR DESCRIPTION
- Add information to user creation.
- User now must input a username, date of birth, region and gender when signing up.
- When user edit their profile via button on profile page they can add additional information such as steam handle, twitch handle etc.
- Add basic button on profile page to link to edit.

![chrome-capture (1)](https://user-images.githubusercontent.com/16850455/131707165-734ca223-d3f8-4ab1-8f2f-14f4545c2d29.jpg)
![chrome-capture (1)](https://user-images.githubusercontent.com/16850455/131707169-c7d34b8c-7c91-494b-902c-e31191c02ba0.gif)

